### PR TITLE
Close the existing socket connection on WriteFailed and re-establish the connection.

### DIFF
--- a/components/socket.go
+++ b/components/socket.go
@@ -86,6 +86,7 @@ func (socket *Socket) SetupSocket(onConnected func(), onError func(error), onMes
 			err := connection.WriteMessage(websocket.TextMessage, message)
 			if err != nil {
 				socket.logger.Debug("Websocket: Write-failed", zap.Error(err))
+				socket.Close() // Close the socket and try to reestablish the connection
 				return
 			}
 		case <-socket.closeSignal:

--- a/components/tunnel.go
+++ b/components/tunnel.go
@@ -100,7 +100,7 @@ func (tunnel *SocketTunnel) onConnected() {
 func (tunnel *SocketTunnel) onError(err error) {
 	tunnel.logger.Error("Tunnel error", zap.Error(err))
 	if !tunnel.socket.IsExited() {
-		tunnel.handleReConnection()
+		tunnel.HandleReConnection()
 	}
 }
 
@@ -229,7 +229,7 @@ func (tunnel *SocketTunnel) onResize(sessionID string, width int64, height int64
 	}
 }
 
-func (tunnel *SocketTunnel) handleReConnection() {
+func (tunnel *SocketTunnel) HandleReConnection() {
 	tunnel.logger.Error("Tunnel is attempting to establish connection in " + fmt.Sprint(tunnel.reconnectWait) + " seconds...")
 	time.Sleep(time.Duration(tunnel.reconnectWait) * time.Second)
 

--- a/pe-terminal.go
+++ b/pe-terminal.go
@@ -80,8 +80,14 @@ func main() {
 		logger.Info("External interrupt, exiting pe-terminal.")
 		os.Exit(1)
 	}()
+
 	// Start tunnel-connection
 	tunnel.Connect()
+
+	for {
+		logger.Error("Tunnel disconnected. Attempting to establish connection")
+		tunnel.HandleReConnection()
+	}
 }
 
 func readConfig(fileName string) Config {


### PR DESCRIPTION

Defect PELEDGE19-4879: pe-terminal sometimes crashes when a user tries to open a terminal
in the Portal. After enabling the debug log level, we found that this happens when
socket writes fails with a broken pipe error which leads to the termination of the program.

After further investigation, I could reproduce this issue only after an Internet outage is restored on the gateway.
Most likely, edge-proxy closes the socket connection established by pe-terminal during a network outage, so next time
when pe-terminal tries to write something on the socket, it throws error - broken pipe.

This fixes the issue by tearing down the connection on which it receives broken pipe error and tries
to re-establish the connection.