### PR TITLE
GitHub Action - golang version matrix

### DIFF
--- a/.github/workflows/PR-checker.yml
+++ b/.github/workflows/PR-checker.yml
@@ -8,6 +8,10 @@ concurrency:
 
 jobs:
   go-build-and-checks:
+    strategy:
+      matrix:
+        # Can't use 1.15 because io.Discard is not defined
+        golang-ver: ["1.16", "1.17", "1.18", "1.19", "1.20"]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -15,7 +19,9 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: ${{ matrix.golang-ver }}
+      - name: Golang version
+        run: go version 
       - name: Set GitHub access token via git config
         run: | 
           git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
@@ -26,6 +32,17 @@ jobs:
         run: scripts-internal/golang/go_build_script.sh --all
       - name: Run make.sh test (go vet + go test)
         run:  ./make.sh test
+
+  pysh-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set GitHub access token via git config
+        run: | 
+          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - name: Check out code
+        uses: actions/checkout@v3
+      - run: git clone git@github.com:PelionIoT/scripts-internal.git
       - name: Run pysh-check
         run: |
            sudo apt install pycodestyle pydocstyle black

--- a/.github/workflows/PR-checker.yml
+++ b/.github/workflows/PR-checker.yml
@@ -1,5 +1,9 @@
 name: Build
-on: push
+on: 
+  push:
+      # Don't run if only the .md -file is changed
+      paths-ignore:
+        - '**/*.md'
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -21,7 +25,7 @@ jobs:
         with:
           go-version: ${{ matrix.golang-ver }}
       - name: Golang version
-        run: go version 
+        run: go version
       - name: Set GitHub access token via git config
         run: | 
           git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pe-terminal
 
+[![License](https://img.shields.io/:license-apache-blue.svg)](LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/PelionIoT/pe-terminal)](https://goreportcard.com/report/github.com/PelionIoT/pe-terminal)
+
 Terminal-client for Izuma Edge Gateways, (formerly [relay-term](https://github.com/PelionIoT/edge-node-modules/tree/master/relay-term) ).
 
 ## How to


### PR DESCRIPTION
We must test with more versions, as we we do use more versions. Yocto for example will follow it's own Yocto versioning etc.

- Golang 1.15 cannot be used as we can't find `io.Discard`.
